### PR TITLE
Fix wacky bubble physics

### DIFF
--- a/bubble/scenes/bubble_1.tscn
+++ b/bubble/scenes/bubble_1.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="AudioStream" uid="uid://bng33wwnnnhj" path="res://sounds/jump_sound.wav" id="4_g80ay"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_ws4pq"]
-radius = 16.0
+radius = 15.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_60lju"]
 atlas = ExtResource("2_6uppf")
@@ -156,6 +156,7 @@ animations = [{
 script = ExtResource("1_voxog")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1)
 shape = SubResource("CircleShape2D_ws4pq")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/bubble/scenes/bubble_2.tscn
+++ b/bubble/scenes/bubble_2.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="AudioStream" uid="uid://bng33wwnnnhj" path="res://sounds/jump_sound.wav" id="4_mbvhs"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_80bc2"]
-radius = 16.0
+radius = 15.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ijs8d"]
 atlas = ExtResource("2_620s4")
@@ -156,6 +156,7 @@ animations = [{
 script = ExtResource("1_7e427")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1)
 shape = SubResource("CircleShape2D_80bc2")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/bubble/scenes/bubble_3.tscn
+++ b/bubble/scenes/bubble_3.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="AudioStream" uid="uid://bng33wwnnnhj" path="res://sounds/jump_sound.wav" id="4_ps0ig"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_tnemu"]
-radius = 16.0
+radius = 15.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_1ribl"]
 atlas = ExtResource("1_ahlap")
@@ -156,6 +156,7 @@ animations = [{
 script = ExtResource("1_axwv4")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1)
 shape = SubResource("CircleShape2D_tnemu")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/bubble/scenes/bubble_4.tscn
+++ b/bubble/scenes/bubble_4.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="AudioStream" uid="uid://bng33wwnnnhj" path="res://sounds/jump_sound.wav" id="4_2jlri"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_s02yg"]
-radius = 16.0
+radius = 15.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_3xh7t"]
 atlas = ExtResource("1_6uu68")
@@ -156,6 +156,7 @@ animations = [{
 script = ExtResource("1_0g8vq")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1)
 shape = SubResource("CircleShape2D_s02yg")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/bubble/scenes/bubble_5.tscn
+++ b/bubble/scenes/bubble_5.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="AudioStream" uid="uid://bng33wwnnnhj" path="res://sounds/jump_sound.wav" id="4_alacc"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_jscmc"]
-radius = 16.0
+radius = 15.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_u88rv"]
 atlas = ExtResource("1_chm2p")
@@ -157,6 +157,7 @@ collision_mask = 2
 script = ExtResource("1_7yvym")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1)
 shape = SubResource("CircleShape2D_jscmc")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/bubble/scripts/bubble_1.gd
+++ b/bubble/scripts/bubble_1.gd
@@ -6,6 +6,7 @@ const JUMP_VELOCITY: float = -250.0
 const IDLE_TIMER: float = 2.0
 const SCALE: Vector2 = Vector2(0.9375, 0.9375)
 
+@onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
 @onready var audio: AudioStreamPlayer2D = $AudioStreamPlayer2D
 
 var active: bool = false
@@ -23,22 +24,22 @@ func _physics_process(delta: float) -> void:
 		velocity += get_gravity() * delta
 		inactive_for = 0.0
 		if active:
-			rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
-		scale.y = move_toward(scale.y, 1.2 * SCALE.y, delta)
+			sprite.rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
+		sprite.scale.y = move_toward(sprite.scale.y, 1.2, delta)
 		$AnimatedSprite2D.play("default")
 		just_landed = 1.0
 	elif inactive_for <= IDLE_TIMER:
 		if just_landed > 0.0:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("jump")
 			just_landed -= delta
-			if rotation != 0:
+			if sprite.rotation != 0:
 				just_landed = 0.0
 		else:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("default")
 	else:
-		scale.y = move_toward(scale.y, SCALE.y, delta)
+		sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 		$AnimatedSprite2D.play("idle")
 
 	# Handle jump.
@@ -52,7 +53,7 @@ func _physics_process(delta: float) -> void:
 	var direction := Input.get_axis("ui_left", "ui_right")
 	if direction and active:
 		velocity.x = direction * SPEED
-		rotation += direction / 5
+		sprite.rotation += direction / 5
 		inactive_for = 0.0
 	else:
 		velocity.x = move_toward(velocity.x, 0, SPEED)

--- a/bubble/scripts/bubble_2.gd
+++ b/bubble/scripts/bubble_2.gd
@@ -6,6 +6,7 @@ const JUMP_VELOCITY: float = -350.0
 const IDLE_TIMER: float = 2.0
 const SCALE: Vector2 = Vector2(0.9375, 0.9375)
 
+@onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
 @onready var audio: AudioStreamPlayer2D = $AudioStreamPlayer2D
 
 var active: bool = false
@@ -23,22 +24,22 @@ func _physics_process(delta: float) -> void:
 		velocity += get_gravity() * delta
 		inactive_for = 0.0
 		if active:
-			rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
-		scale.y = move_toward(scale.y, 1.2 * SCALE.y, delta)
+			sprite.rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
+		sprite.scale.y = move_toward(sprite.scale.y, 1.2, delta)
 		$AnimatedSprite2D.play("default")
 		just_landed = 1.0
 	elif inactive_for <= IDLE_TIMER:
 		if just_landed > 0.0:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("jump")
 			just_landed -= delta
-			if rotation != 0:
+			if sprite.rotation != 0:
 				just_landed = 0.0
 		else:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("default")
 	else:
-		scale.y = move_toward(scale.y, SCALE.y, delta)
+		sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 		$AnimatedSprite2D.play("idle")
 
 	# Handle jump.
@@ -52,7 +53,7 @@ func _physics_process(delta: float) -> void:
 	var direction := Input.get_axis("ui_left", "ui_right")
 	if direction and active:
 		velocity.x = direction * SPEED
-		rotation += direction / 5
+		sprite.rotation += direction / 5
 		inactive_for = 0.0
 	else:
 		velocity.x = move_toward(velocity.x, 0, SPEED)

--- a/bubble/scripts/bubble_3.gd
+++ b/bubble/scripts/bubble_3.gd
@@ -7,6 +7,7 @@ const IDLE_TIMER: float = 2.0
 const SCALE: Vector2 = Vector2(0.9375, 0.9375)
 const PUSH_FORCE: float = 34.5
 
+@onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
 @onready var audio: AudioStreamPlayer2D = $AudioStreamPlayer2D
 
 var active: bool = false
@@ -26,22 +27,22 @@ func _physics_process(delta: float) -> void:
 		velocity += get_gravity() * delta
 		inactive_for = 0.0
 		if active:
-			rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
-		scale.y = move_toward(scale.y, 1.2 * SCALE.y, delta)
+			sprite.rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
+		sprite.scale.y = move_toward(sprite.scale.y, 1.2, delta)
 		$AnimatedSprite2D.play("default")
 		just_landed = 1.0
 	elif inactive_for <= IDLE_TIMER:
 		if just_landed > 0.0:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("jump")
 			just_landed -= delta
-			if rotation != 0:
+			if sprite.rotation != 0:
 				just_landed = 0.0
 		else:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("default")
 	else:
-		scale.y = move_toward(scale.y, SCALE.y, delta)
+		sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 		$AnimatedSprite2D.play("idle")
 
 	# Handle jump.
@@ -55,7 +56,7 @@ func _physics_process(delta: float) -> void:
 	var direction := Input.get_axis("ui_left", "ui_right")
 	if direction and active:
 		velocity.x = direction * SPEED
-		rotation += direction / 5
+		sprite.rotation += direction / 5
 		inactive_for = 0.0
 	else:
 		velocity.x = move_toward(velocity.x, 0, SPEED)

--- a/bubble/scripts/bubble_4.gd
+++ b/bubble/scripts/bubble_4.gd
@@ -6,6 +6,7 @@ const JUMP_VELOCITY: float = -250.0
 const IDLE_TIMER: float = 2.0
 const SCALE: Vector2 = Vector2(0.9375, 0.9375)
 
+@onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
 @onready var audio: AudioStreamPlayer2D = $AudioStreamPlayer2D
 
 var active: bool = false
@@ -23,22 +24,22 @@ func _physics_process(delta: float) -> void:
 		velocity += get_gravity() * delta
 		inactive_for = 0.0
 		if active:
-			rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
-		scale.y = move_toward(scale.y, 1.2 * SCALE.y, delta)
+			sprite.rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
+		sprite.scale.y = move_toward(sprite.scale.y, 1.2, delta)
 		$AnimatedSprite2D.play("default")
 		just_landed = 1.0
 	elif inactive_for <= IDLE_TIMER:
 		if just_landed > 0.0:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("jump")
 			just_landed -= delta
-			if rotation != 0:
+			if sprite.rotation != 0:
 				just_landed = 0.0
 		else:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("default")
 	else:
-		scale.y = move_toward(scale.y, SCALE.y, delta)
+		sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 		$AnimatedSprite2D.play("idle")
 
 	# Handle jump.
@@ -52,7 +53,7 @@ func _physics_process(delta: float) -> void:
 	var direction := Input.get_axis("ui_left", "ui_right")
 	if direction and active:
 		velocity.x = direction * SPEED
-		rotation += direction / 5
+		sprite.rotation += direction / 5
 		inactive_for = 0.0
 	else:
 		velocity.x = move_toward(velocity.x, 0, SPEED)

--- a/bubble/scripts/bubble_5.gd
+++ b/bubble/scripts/bubble_5.gd
@@ -6,6 +6,7 @@ const JUMP_VELOCITY: float = -250.0
 const IDLE_TIMER: float = 2.0
 const SCALE: Vector2 = Vector2(0.9375, 0.9375)
 
+@onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
 @onready var audio: AudioStreamPlayer2D = $AudioStreamPlayer2D
 
 var active: bool = false
@@ -23,22 +24,22 @@ func _physics_process(delta: float) -> void:
 		velocity += get_gravity() * delta
 		inactive_for = 0.0
 		if active:
-			rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
-		scale.y = move_toward(scale.y, 1.2 * SCALE.y, delta)
+			sprite.rotation_degrees = Input.get_axis("ui_left", "ui_right") * 45
+		sprite.scale.y = move_toward(sprite.scale.y, 1.2, delta)
 		$AnimatedSprite2D.play("default")
 		just_landed = 1.0
 	elif inactive_for <= IDLE_TIMER:
 		if just_landed > 0.0:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("jump")
 			just_landed -= delta
-			if rotation != 0:
+			if sprite.rotation != 0:
 				just_landed = 0.0
 		else:
-			scale.y = move_toward(scale.y, SCALE.y, delta)
+			sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 			$AnimatedSprite2D.play("default")
 	else:
-		scale.y = move_toward(scale.y, SCALE.y, delta)
+		sprite.scale.y = move_toward(sprite.scale.y, 1, delta)
 		$AnimatedSprite2D.play("idle")
 
 	# Handle jump.
@@ -52,7 +53,7 @@ func _physics_process(delta: float) -> void:
 	var direction := Input.get_axis("ui_left", "ui_right")
 	if direction and active:
 		velocity.x = direction * SPEED
-		rotation += direction / 5
+		sprite.rotation += direction / 5
 		inactive_for = 0.0
 	else:
 		velocity.x = move_toward(velocity.x, 0, SPEED)


### PR DESCRIPTION
Due to the game being a typical example of what game jams do to codebases, certain weird phenomena have transpired and flown under the radar. Namely, even though the bubbles' collision shapes were all circles, and rotation of said shapes shouldn't change anything (or so I thought, given how a rotated circle looks the same before and after, shape-wise), it turns out that Godot doesn't like when a `CharacterBody2D`'s collision shape changes. I guess.

Now that that has been taken care of, the game feels and plays so much better.
